### PR TITLE
Implement loot results and XP gain

### DIFF
--- a/src/main/kotlin/core/data/GameDefinitions.kt
+++ b/src/main/kotlin/core/data/GameDefinitions.kt
@@ -32,6 +32,7 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 class GameDefinitions(onResourceLoadComplete: () -> Unit) {
     val itemsById = mutableMapOf<String, ItemResource>()
+    val itemsByIdUppercased = mutableMapOf<String, ItemResource>()
     val itemsByType = mutableMapOf<String, MutableList<ItemResource>>()
     val itemsByLootable = mutableMapOf<String, MutableList<ItemResource>>()
 
@@ -75,5 +76,11 @@ class GameDefinitions(onResourceLoadComplete: () -> Unit) {
             Logger.info { "📦 Finished parsing $resName in ${(end - start).milliseconds}" }
         }
         onResourceLoadComplete()
+    }
+
+    // in some cases, the game sends the server uppercased id
+    fun findItem(id: String): ItemResource? {
+        // prefer exact match first
+        return itemsById[id] ?: itemsByIdUppercased[id.uppercase()]
     }
 }

--- a/src/main/kotlin/core/data/parser/ItemsParser.kt
+++ b/src/main/kotlin/core/data/parser/ItemsParser.kt
@@ -27,6 +27,7 @@ class ItemsParser() : GameResourcesParser {
             val res = ItemResource(itemId, itemType, itemNode)
 
             gameDefinitions.itemsById.putIfAbsent(itemId, res)
+            gameDefinitions.itemsByIdUppercased.putIfAbsent(itemId.uppercase(), res)
             gameDefinitions.itemsByType.computeIfAbsent(itemId) { mutableListOf() }.add(res)
             if (itemLocs?.isNotEmpty() ?: false) {
                 val locList = itemLocs.split(',').map { it.trim() }

--- a/src/main/kotlin/core/items/ItemFactory.kt
+++ b/src/main/kotlin/core/items/ItemFactory.kt
@@ -15,9 +15,8 @@ object ItemFactory {
     }
 
     fun createItemFromId(itemId: String = UUID.new(), idInXML: String): Item {
-        val res =
-            gameResourceRegistry.itemsById[idInXML]
-                ?: throw IllegalArgumentException("Failed creating Item id=$itemId from xml id=$idInXML (xml id not found)")
+        val res = gameResourceRegistry.findItem(idInXML)
+            ?: throw IllegalArgumentException("Failed creating Item id=$itemId from xml id=$idInXML (xml id not found)")
         return createItemFromResource(itemId, res)
     }
 

--- a/src/main/kotlin/core/mission/LootService.kt
+++ b/src/main/kotlin/core/mission/LootService.kt
@@ -36,7 +36,6 @@ class LootService(
     val cumulativeLootsPerLoc: MutableMap<String, TreeMap<Double, LootContent>> = mutableMapOf()
     val totalWeightPerLoc: MutableMap<String, Double> = mutableMapOf()
     val insertedLoots: MutableList<LootContent> = mutableListOf()
-    val itemsLootedByPlayer: MutableList<LootContent> = mutableListOf()
 
     init {
         buildIndexOfLootableItems()
@@ -134,9 +133,13 @@ class LootService(
                 val itmsElement = doc.createElement("itms")
 
                 val loots = getRollsFromLocs(srchNode.textContent.split(","))
-                for ((id, type, q) in loots) {
+                for ((_, type, q) in loots) {
                     val itm = doc.createElement("itm")
-                    itm.setAttribute("id", id)
+                    // the id here is not used to construct an Item
+                    // it is used for reference, in which client will send it during mission end
+                    // to let server know which items are looted.
+                    // therefore, we used type for the id
+                    itm.setAttribute("id", type)
                     itm.setAttribute("type", type)
                     itm.setAttribute("q", q.toString())
                     itmsElement.appendChild(itm)

--- a/src/main/kotlin/socket/messaging/NetworkMessage.kt
+++ b/src/main/kotlin/socket/messaging/NetworkMessage.kt
@@ -63,7 +63,7 @@ object NetworkMessage {
     const val UPGRADE_FLAG_CHANGED = "ufc"
     const val MISSION_EVENT = "me"
     const val PVP_LIST_UPDATE = "pvplist"
-    const val SCAV_STARTED = "sc =strt"
+    const val SCAV_STARTED = "scvstrt"
     const val SCAV_ENDED = "scvend"
     const val FUEL_UPDATE = "fuel"
     const val TRADE_DISABLED = "td"


### PR DESCRIPTION
This commit tries to gives player items they looted from mission.

1. There is inconsistency in client-server, where both relies on case-sensitive items ID. However, client somewhere insist on sending items ID as uppercase, hence the addition of `itemsByIdUppercased`.
2. The issue with player not receiving loot is simply because the server haven't give the loot to player. This commit implements code that reads "loot" on MISSION_END save data request to aggregate the list of items and count that the player loots.
3. The XP is calculated by player's kill to zombie, this is included in STAT_DATA.

There are still many TO-DO to implements, such as more accurately representing XP gain (the formula here is 1-100XP per kill, not based on zombie XP). Timer is only 20 second here, and I haven't send mission timer completion signal to client. And many more...